### PR TITLE
test: add tests for content service and health endpoint

### DIFF
--- a/backend/tests/test_content_service.py
+++ b/backend/tests/test_content_service.py
@@ -1,0 +1,24 @@
+from app.services.content_service import filter_places, get_supported_cities, load_places
+
+
+def test_load_places():
+    places = load_places()
+    assert len(places) > 0
+    assert "Stockholm" in get_supported_cities()
+
+
+def test_filer_stockholm_attraction():
+    places = filter_places(city="Stockholm", category="attration")
+    assert places
+    assert all(place.city == "Stockholm" for place in places)
+    assert all(place.category == "attraction" for place in places)
+
+
+def test_filter_budget_family_environment():
+    places = filter_places(
+        city="Copenhagen",
+        budget="low",
+        family_friendly=True,
+        environment="outdoors"
+        )
+    assert places

--- a/backend/tests/test_content_service.py
+++ b/backend/tests/test_content_service.py
@@ -8,7 +8,7 @@ def test_load_places():
 
 
 def test_filer_stockholm_attraction():
-    places = filter_places(city="Stockholm", category="attration")
+    places = filter_places(city="Stockholm", category="attraction")
     assert places
     assert all(place.city == "Stockholm" for place in places)
     assert all(place.category == "attraction" for place in places)

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_healthcheck() -> None:
+    client = TestClient(app)
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary

Adds unit tests for content service filtering and the `/health` endpoint.

## Changes

* Added tests for `filter_places` and `load_places`
* Validates filtering by city, category, budget, family_friendly, and environment
* Added test for `/health` endpoint using TestClient
* Verifies status code is 200 and response is `{"status": "ok"}`

## Why

Improves test coverage and ensures core functionality (filtering + healthcheck) works correctly.

## How to test

Run:
pytest

## Scope

Only test files added, no changes to application logic.
